### PR TITLE
Optimize Circuits and Benches

### DIFF
--- a/aggregator/Cargo.toml
+++ b/aggregator/Cargo.toml
@@ -20,6 +20,7 @@ indexed-merkle-tree-halo2 = { git = "https://github.com/aerius-labs/indexed-merk
 rand_chacha = "0.3.1"
 snark-verifier-sdk = { git = "https://github.com/aerius-labs/snark-verifier.git", branch = "feat/custom" }
 ark-std = "0.4.0"
+num-traits = "0.2.18"
 
 voter = { path = "../voter" }
 voter-tests = { path = "../voter_tests" }

--- a/aggregator/benches/state_transition_circuit.rs
+++ b/aggregator/benches/state_transition_circuit.rs
@@ -1,96 +1,97 @@
-use aggregator::state_transition::{state_transition_circuit, StateTransitionInput};
-use aggregator::utils::generate_random_state_transition_circuit_inputs;
-use ark_std::{end_timer, start_timer};
-use halo2_base::gates::circuit::BaseCircuitParams;
-use halo2_base::gates::circuit::{builder::RangeCircuitBuilder, CircuitBuilderStage};
-use halo2_base::gates::flex_gate::MultiPhaseThreadBreakPoints;
-use halo2_base::AssignedValue;
-use halo2_base::{
-    halo2_proofs::{
-        halo2curves::bn256::{Bn256, Fr},
-        plonk::*,
-        poly::kzg::commitment::ParamsKZG,
-    },
-    utils::testing::gen_proof,
-};
-use pprof::criterion::{Output, PProfProfiler};
-use rand::rngs::OsRng;
+// use aggregator::state_transition::{state_transition_circuit, StateTransitionInput};
+// use aggregator::utils::generate_random_state_transition_circuit_inputs;
+// use ark_std::{end_timer, start_timer};
+// use halo2_base::gates::circuit::BaseCircuitParams;
+// use halo2_base::gates::circuit::{builder::RangeCircuitBuilder, CircuitBuilderStage};
+// use halo2_base::gates::flex_gate::MultiPhaseThreadBreakPoints;
+// use halo2_base::AssignedValue;
+// use halo2_base::{
+//     halo2_proofs::{
+//         halo2curves::bn256::{Bn256, Fr},
+//         plonk::*,
+//         poly::kzg::commitment::ParamsKZG,
+//     },
+//     utils::testing::gen_proof,
+// };
+// use pprof::criterion::{Output, PProfProfiler};
+// use rand::rngs::OsRng;
 
-use criterion::{criterion_group, criterion_main};
-use criterion::{BenchmarkId, Criterion};
+// use criterion::{criterion_group, criterion_main};
+// use criterion::{BenchmarkId, Criterion};
 
-const K: u32 = 15;
+// const K: u32 = 15;
 
-fn state_transition_circuit_bench(
-    stage: CircuitBuilderStage,
-    input: StateTransitionInput<Fr>,
-    config_params: Option<BaseCircuitParams>,
-    break_points: Option<MultiPhaseThreadBreakPoints>,
-) -> RangeCircuitBuilder<Fr> {
-    let k = K as usize;
-    let lookup_bits = k - 1;
-    let mut builder = match stage {
-        CircuitBuilderStage::Prover => {
-            RangeCircuitBuilder::prover(config_params.unwrap(), break_points.unwrap())
-        }
-        _ => RangeCircuitBuilder::from_stage(stage)
-            .use_k(k)
-            .use_lookup_bits(lookup_bits),
-    };
+// fn state_transition_circuit_bench(
+//     stage: CircuitBuilderStage,
+//     input: StateTransitionInput<Fr>,
+//     config_params: Option<BaseCircuitParams>,
+//     break_points: Option<MultiPhaseThreadBreakPoints>,
+// ) -> RangeCircuitBuilder<Fr> {
+//     let k = K as usize;
+//     let lookup_bits = k - 1;
+//     let mut builder = match stage {
+//         CircuitBuilderStage::Prover => {
+//             RangeCircuitBuilder::prover(config_params.unwrap(), break_points.unwrap())
+//         }
+//         _ => RangeCircuitBuilder::from_stage(stage)
+//             .use_k(k)
+//             .use_lookup_bits(lookup_bits),
+//     };
 
-    let start0 = start_timer!(|| format!("Witness generation for circuit in {stage:?} stage"));
-    let range = builder.range_chip();
+//     let start0 = start_timer!(|| format!("Witness generation for circuit in {stage:?} stage"));
+//     let range = builder.range_chip();
 
-    let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
-    state_transition_circuit(builder.main(0), &range, input, &mut public_inputs);
+//     let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
+//     state_transition_circuit(builder.main(0), &range, input, &mut public_inputs);
 
-    end_timer!(start0);
-    if !stage.witness_gen_only() {
-        builder.calculate_params(Some(20));
-    }
-    builder
-}
+//     end_timer!(start0);
+//     if !stage.witness_gen_only() {
+//         builder.calculate_params(Some(20));
+//     }
+//     builder
+// }
 
-fn bench(c: &mut Criterion) {
-    let state_transition_input = generate_random_state_transition_circuit_inputs();
-    let circuit = state_transition_circuit_bench(
-        CircuitBuilderStage::Keygen,
-        state_transition_input.clone(),
-        None,
-        None,
-    );
-    let config_params = circuit.params();
+// fn bench(c: &mut Criterion) {
+//     let state_transition_input = generate_random_state_transition_circuit_inputs();
+//     let circuit = state_transition_circuit_bench(
+//         CircuitBuilderStage::Keygen,
+//         state_transition_input.clone(),
+//         None,
+//         None,
+//     );
+//     let config_params = circuit.params();
 
-    let params = ParamsKZG::<Bn256>::setup(K, OsRng);
-    let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
-    let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
-    let break_points = circuit.break_points();
+//     let params = ParamsKZG::<Bn256>::setup(K, OsRng);
+//     let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
+//     let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
+//     let break_points = circuit.break_points();
 
-    let mut group = c.benchmark_group("plonk-prover");
-    group.sample_size(10);
-    group.bench_with_input(
-        BenchmarkId::new("state transition circuit", K),
-        &(&params, &pk, &state_transition_input),
-        |bencher, &(params, pk, state_transition_input)| {
-            let input = state_transition_input.clone();
-            bencher.iter(|| {
-                let circuit = state_transition_circuit_bench(
-                    CircuitBuilderStage::Prover,
-                    input.clone(),
-                    Some(config_params.clone()),
-                    Some(break_points.clone()),
-                );
+//     let mut group = c.benchmark_group("plonk-prover");
+//     group.sample_size(10);
+//     group.bench_with_input(
+//         BenchmarkId::new("state transition circuit", K),
+//         &(&params, &pk, &state_transition_input),
+//         |bencher, &(params, pk, state_transition_input)| {
+//             let input = state_transition_input.clone();
+//             bencher.iter(|| {
+//                 let circuit = state_transition_circuit_bench(
+//                     CircuitBuilderStage::Prover,
+//                     input.clone(),
+//                     Some(config_params.clone()),
+//                     Some(break_points.clone()),
+//                 );
 
-                gen_proof(params, pk, circuit);
-            })
-        },
-    );
-    group.finish()
-}
+//                 gen_proof(params, pk, circuit);
+//             })
+//         },
+//     );
+//     group.finish()
+// }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
-    targets = bench
-}
-criterion_main!(benches);
+// criterion_group! {
+//     name = benches;
+//     config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
+//     targets = bench
+// }
+// criterion_main!(benches);
+fn main() {}

--- a/aggregator/benches/state_transition_circuit.rs
+++ b/aggregator/benches/state_transition_circuit.rs
@@ -1,97 +1,128 @@
-// use aggregator::state_transition::{state_transition_circuit, StateTransitionInput};
-// use aggregator::utils::generate_random_state_transition_circuit_inputs;
-// use ark_std::{end_timer, start_timer};
-// use halo2_base::gates::circuit::BaseCircuitParams;
-// use halo2_base::gates::circuit::{builder::RangeCircuitBuilder, CircuitBuilderStage};
-// use halo2_base::gates::flex_gate::MultiPhaseThreadBreakPoints;
-// use halo2_base::AssignedValue;
-// use halo2_base::{
-//     halo2_proofs::{
-//         halo2curves::bn256::{Bn256, Fr},
-//         plonk::*,
-//         poly::kzg::commitment::ParamsKZG,
-//     },
-//     utils::testing::gen_proof,
-// };
-// use pprof::criterion::{Output, PProfProfiler};
-// use rand::rngs::OsRng;
+use aggregator::state_transition::{state_transition_circuit, StateTransitionInput};
+use aggregator::utils::{
+    assign_big_uint, compress_native_nullifier, generate_random_state_transition_circuit_inputs,
+};
+use ark_std::{end_timer, start_timer};
+use halo2_base::gates::circuit::BaseCircuitParams;
+use halo2_base::gates::circuit::{builder::RangeCircuitBuilder, CircuitBuilderStage};
+use halo2_base::gates::flex_gate::MultiPhaseThreadBreakPoints;
+use halo2_base::AssignedValue;
+use halo2_base::{
+    halo2_proofs::{
+        halo2curves::bn256::{Bn256, Fr},
+        plonk::*,
+        poly::kzg::commitment::ParamsKZG,
+    },
+    utils::testing::gen_proof,
+};
+use pprof::criterion::{Output, PProfProfiler};
+use rand::rngs::OsRng;
 
-// use criterion::{criterion_group, criterion_main};
-// use criterion::{BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion};
 
-// const K: u32 = 15;
+const K: u32 = 15;
 
-// fn state_transition_circuit_bench(
-//     stage: CircuitBuilderStage,
-//     input: StateTransitionInput<Fr>,
-//     config_params: Option<BaseCircuitParams>,
-//     break_points: Option<MultiPhaseThreadBreakPoints>,
-// ) -> RangeCircuitBuilder<Fr> {
-//     let k = K as usize;
-//     let lookup_bits = k - 1;
-//     let mut builder = match stage {
-//         CircuitBuilderStage::Prover => {
-//             RangeCircuitBuilder::prover(config_params.unwrap(), break_points.unwrap())
-//         }
-//         _ => RangeCircuitBuilder::from_stage(stage)
-//             .use_k(k)
-//             .use_lookup_bits(lookup_bits),
-//     };
+fn state_transition_circuit_bench(
+    stage: CircuitBuilderStage,
+    input: StateTransitionInput<Fr>,
+    config_params: Option<BaseCircuitParams>,
+    break_points: Option<MultiPhaseThreadBreakPoints>,
+) -> RangeCircuitBuilder<Fr> {
+    let k = K as usize;
+    let lookup_bits = k - 1;
+    let mut builder = match stage {
+        CircuitBuilderStage::Prover => {
+            RangeCircuitBuilder::prover(config_params.unwrap(), break_points.unwrap())
+        }
+        _ => RangeCircuitBuilder::from_stage(stage)
+            .use_k(k)
+            .use_lookup_bits(lookup_bits),
+    };
 
-//     let start0 = start_timer!(|| format!("Witness generation for circuit in {stage:?} stage"));
-//     let range = builder.range_chip();
+    let start0 = start_timer!(|| format!("Witness generation for circuit in {stage:?} stage"));
+    let range = builder.range_chip();
 
-//     let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
-//     state_transition_circuit(builder.main(0), &range, input, &mut public_inputs);
+    let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
+    let mut state_transition_vec = Vec::<AssignedValue<Fr>>::new();
+    let ctx = builder.main(0);
 
-//     end_timer!(start0);
-//     if !stage.witness_gen_only() {
-//         builder.calculate_params(Some(20));
-//     }
-//     builder
-// }
+    state_transition_vec.extend(
+        compress_native_nullifier(&input.nullifier)
+            .iter()
+            .map(|&x| ctx.load_witness(x)),
+    );
 
-// fn bench(c: &mut Criterion) {
-//     let state_transition_input = generate_random_state_transition_circuit_inputs();
-//     let circuit = state_transition_circuit_bench(
-//         CircuitBuilderStage::Keygen,
-//         state_transition_input.clone(),
-//         None,
-//         None,
-//     );
-//     let config_params = circuit.params();
+    let enc_g = input.pk_enc.g;
+    let enc_h = input.pk_enc.n;
 
-//     let params = ParamsKZG::<Bn256>::setup(K, OsRng);
-//     let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
-//     let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
-//     let break_points = circuit.break_points();
+    state_transition_vec.extend(assign_big_uint(ctx, &enc_g));
+    state_transition_vec.extend(assign_big_uint(ctx, &enc_h));
 
-//     let mut group = c.benchmark_group("plonk-prover");
-//     group.sample_size(10);
-//     group.bench_with_input(
-//         BenchmarkId::new("state transition circuit", K),
-//         &(&params, &pk, &state_transition_input),
-//         |bencher, &(params, pk, state_transition_input)| {
-//             let input = state_transition_input.clone();
-//             bencher.iter(|| {
-//                 let circuit = state_transition_circuit_bench(
-//                     CircuitBuilderStage::Prover,
-//                     input.clone(),
-//                     Some(config_params.clone()),
-//                     Some(break_points.clone()),
-//                 );
+    state_transition_vec.extend(
+        input
+            .incoming_vote
+            .iter()
+            .flat_map(|x| assign_big_uint(ctx, x)),
+    );
 
-//                 gen_proof(params, pk, circuit);
-//             })
-//         },
-//     );
-//     group.finish()
-// }
+    state_transition_vec.extend(input.prev_vote.iter().flat_map(|x| assign_big_uint(ctx, x)));
 
-// criterion_group! {
-//     name = benches;
-//     config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
-//     targets = bench
-// }
-// criterion_main!(benches);
-fn main() {}
+    state_transition_circuit(
+        ctx,
+        &range,
+        input.nullifier_tree,
+        state_transition_vec,
+        &mut public_inputs,
+    );
+
+    end_timer!(start0);
+    if !stage.witness_gen_only() {
+        builder.calculate_params(Some(20));
+    }
+    builder
+}
+
+fn bench(c: &mut Criterion) {
+    let state_transition_input = generate_random_state_transition_circuit_inputs();
+    let circuit = state_transition_circuit_bench(
+        CircuitBuilderStage::Keygen,
+        state_transition_input.clone(),
+        None,
+        None,
+    );
+    let config_params = circuit.params();
+
+    let params = ParamsKZG::<Bn256>::setup(K, OsRng);
+    let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
+    let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
+    let break_points = circuit.break_points();
+
+    let mut group = c.benchmark_group("plonk-prover");
+    group.sample_size(10);
+    group.bench_with_input(
+        BenchmarkId::new("state transition circuit", K),
+        &(&params, &pk, &state_transition_input),
+        |bencher, &(params, pk, state_transition_input)| {
+            let input = state_transition_input.clone();
+            bencher.iter(|| {
+                let circuit = state_transition_circuit_bench(
+                    CircuitBuilderStage::Prover,
+                    input.clone(),
+                    Some(config_params.clone()),
+                    Some(break_points.clone()),
+                );
+
+                gen_proof(params, pk, circuit);
+            })
+        },
+    );
+    group.finish()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
+    targets = bench
+}
+criterion_main!(benches);

--- a/aggregator/benches/wrapper_circuit.rs
+++ b/aggregator/benches/wrapper_circuit.rs
@@ -1,152 +1,153 @@
-use aggregator::state_transition::StateTransitionCircuit;
-use aggregator::utils::generate_wrapper_circuit_input;
-use aggregator::wrapper::common::gen_dummy_snark;
-use aggregator::wrapper::common::gen_pk;
-use aggregator::wrapper::common::gen_snark;
-use aggregator::wrapper::recursion::RecursionCircuit;
-use halo2_base::gates::circuit::BaseCircuitParams;
-use halo2_base::gates::circuit::CircuitBuilderStage;
-use halo2_base::utils::fs::gen_srs;
-use halo2_base::{
-    halo2_proofs::{halo2curves::bn256::Fr, plonk::*},
-    utils::testing::gen_proof,
-};
+// use aggregator::state_transition::StateTransitionCircuit;
+// use aggregator::utils::generate_wrapper_circuit_input;
+// use aggregator::wrapper::common::gen_dummy_snark;
+// use aggregator::wrapper::common::gen_pk;
+// use aggregator::wrapper::common::gen_snark;
+// use aggregator::wrapper::recursion::RecursionCircuit;
+// use halo2_base::gates::circuit::BaseCircuitParams;
+// use halo2_base::gates::circuit::CircuitBuilderStage;
+// use halo2_base::utils::fs::gen_srs;
+// use halo2_base::{
+//     halo2_proofs::{halo2curves::bn256::Fr, plonk::*},
+//     utils::testing::gen_proof,
+// };
 
-use criterion::{criterion_group, criterion_main};
-use criterion::{BenchmarkId, Criterion};
+// use criterion::{criterion_group, criterion_main};
+// use criterion::{BenchmarkId, Criterion};
 
-use pprof::criterion::{Output, PProfProfiler};
-use voter::VoterCircuit;
+// use pprof::criterion::{Output, PProfProfiler};
+// use voter::VoterCircuit;
 
-const K: u32 = 22;
+// const K: u32 = 22;
 
-fn bench(c: &mut Criterion) {
-    let (voter_inputs, state_transition_inputs) = generate_wrapper_circuit_input(1);
+// fn bench(c: &mut Criterion) {
+//     let (voter_inputs, state_transition_inputs) = generate_wrapper_circuit_input(1);
 
-    // Generating voter proof
-    let voter_config = BaseCircuitParams {
-        k: 15,
-        num_advice_per_phase: vec![1],
-        num_lookup_advice_per_phase: vec![1, 0, 0],
-        num_fixed: 1,
-        lookup_bits: Some(14),
-        num_instance_columns: 1,
-    };
-    let voter_params = gen_srs(15);
-    let voter_circuit = VoterCircuit::new(voter_config.clone(), voter_inputs[0].clone());
-    let voter_pk = gen_pk(&voter_params, &voter_circuit);
-    let voter_snark = gen_snark(&voter_params, &voter_pk, voter_circuit);
+//     // Generating voter proof
+//     let voter_config = BaseCircuitParams {
+//         k: 15,
+//         num_advice_per_phase: vec![1],
+//         num_lookup_advice_per_phase: vec![1, 0, 0],
+//         num_fixed: 1,
+//         lookup_bits: Some(14),
+//         num_instance_columns: 1,
+//     };
+//     let voter_params = gen_srs(15);
+//     let voter_circuit = VoterCircuit::new(voter_config.clone(), voter_inputs[0].clone());
+//     let voter_pk = gen_pk(&voter_params, &voter_circuit);
+//     let voter_snark = gen_snark(&voter_params, &voter_pk, voter_circuit);
 
-    // Generating state transition proof
-    let state_transition_config = BaseCircuitParams {
-        k: 15,
-        num_advice_per_phase: vec![3],
-        num_lookup_advice_per_phase: vec![1, 0, 0],
-        num_fixed: 1,
-        lookup_bits: Some(14),
-        num_instance_columns: 1,
-    };
-    let state_transition_params = gen_srs(15);
-    let state_transition_circuit = StateTransitionCircuit::new(
-        state_transition_config.clone(),
-        state_transition_inputs[0].clone(),
-    );
-    let state_transition_pk = gen_pk(&state_transition_params, &state_transition_circuit);
-    let state_transition_snark = gen_snark(
-        &state_transition_params,
-        &state_transition_pk,
-        state_transition_circuit,
-    );
+//     // Generating state transition proof
+//     let state_transition_config = BaseCircuitParams {
+//         k: 15,
+//         num_advice_per_phase: vec![3],
+//         num_lookup_advice_per_phase: vec![1, 0, 0],
+//         num_fixed: 1,
+//         lookup_bits: Some(14),
+//         num_instance_columns: 1,
+//     };
+//     let state_transition_params = gen_srs(15);
+//     let state_transition_circuit = StateTransitionCircuit::new(
+//         state_transition_config.clone(),
+//         state_transition_inputs[0].clone(),
+//     );
+//     let state_transition_pk = gen_pk(&state_transition_params, &state_transition_circuit);
+//     let state_transition_snark = gen_snark(
+//         &state_transition_params,
+//         &state_transition_pk,
+//         state_transition_circuit,
+//     );
 
-    let recursion_config = BaseCircuitParams {
-        k: K as usize,
-        num_advice_per_phase: vec![4],
-        num_lookup_advice_per_phase: vec![1, 0, 0],
-        num_fixed: 1,
-        lookup_bits: Some((K - 1) as usize),
-        num_instance_columns: 1,
-    };
-    let recursion_params = gen_srs(K);
+//     let recursion_config = BaseCircuitParams {
+//         k: K as usize,
+//         num_advice_per_phase: vec![4],
+//         num_lookup_advice_per_phase: vec![1, 0, 0],
+//         num_fixed: 1,
+//         lookup_bits: Some((K - 1) as usize),
+//         num_instance_columns: 1,
+//     };
+//     let recursion_params = gen_srs(K);
 
-    // Init Base Instances
-    let mut base_instances = [
-        Fr::zero(),                  // preprocessed_digest
-        voter_snark.instances[0][0], // pk_enc_n
-        voter_snark.instances[0][1],
-        voter_snark.instances[0][2], // pk_enc_g
-        voter_snark.instances[0][3],
-    ]
-    .to_vec();
-    base_instances.extend(state_transition_snark.instances[0][4..24].iter()); // init_vote
-    base_instances.extend([
-        state_transition_snark.instances[0][68], // nullifier_old_root
-        state_transition_snark.instances[0][68], // nullifier_new_root
-        voter_snark.instances[0][28],            // membership_root
-        voter_snark.instances[0][29],            // proposal_id
-        Fr::from(0),                             // round
-    ]);
+//     // Init Base Instances
+//     let mut base_instances = [
+//         Fr::zero(),                  // preprocessed_digest
+//         voter_snark.instances[0][0], // pk_enc_n
+//         voter_snark.instances[0][1],
+//         voter_snark.instances[0][2], // pk_enc_g
+//         voter_snark.instances[0][3],
+//     ]
+//     .to_vec();
+//     base_instances.extend(state_transition_snark.instances[0][4..24].iter()); // init_vote
+//     base_instances.extend([
+//         state_transition_snark.instances[0][68], // nullifier_old_root
+//         state_transition_snark.instances[0][68], // nullifier_new_root
+//         voter_snark.instances[0][28],            // membership_root
+//         voter_snark.instances[0][29],            // proposal_id
+//         Fr::from(0),                             // round
+//     ]);
 
-    let recursion_circuit = RecursionCircuit::new(
-        CircuitBuilderStage::Keygen,
-        &recursion_params,
-        gen_dummy_snark::<VoterCircuit<Fr>>(&voter_params, Some(voter_pk.get_vk()), voter_config),
-        gen_dummy_snark::<StateTransitionCircuit<Fr>>(
-            &state_transition_params,
-            Some(state_transition_pk.get_vk()),
-            state_transition_config,
-        ),
-        RecursionCircuit::initial_snark(
-            &recursion_params,
-            None,
-            recursion_config.clone(),
-            base_instances.clone(),
-        ),
-        0,
-        recursion_config,
-    );
-    let pk = gen_pk(&recursion_params, &recursion_circuit);
-    let config_params = recursion_circuit.inner().params();
+//     let recursion_circuit = RecursionCircuit::new(
+//         CircuitBuilderStage::Keygen,
+//         &recursion_params,
+//         gen_dummy_snark::<VoterCircuit<Fr>>(&voter_params, Some(voter_pk.get_vk()), voter_config),
+//         gen_dummy_snark::<StateTransitionCircuit<Fr>>(
+//             &state_transition_params,
+//             Some(state_transition_pk.get_vk()),
+//             state_transition_config,
+//         ),
+//         RecursionCircuit::initial_snark(
+//             &recursion_params,
+//             None,
+//             recursion_config.clone(),
+//             base_instances.clone(),
+//         ),
+//         0,
+//         recursion_config,
+//     );
+//     let pk = gen_pk(&recursion_params, &recursion_circuit);
+//     let config_params = recursion_circuit.inner().params();
 
-    let mut group = c.benchmark_group("plonk-prover");
-    group.sample_size(10);
-    group.bench_with_input(
-        BenchmarkId::new("wrapper circuit", K),
-        &(
-            &recursion_params,
-            &pk,
-            &voter_snark,
-            &state_transition_snark,
-        ),
-        |bencher, &(params, pk, voter_snark, state_transition_snark)| {
-            let cloned_voter_snark = voter_snark;
-            let cloned_state_transition_snark = state_transition_snark;
-            bencher.iter(|| {
-                let cloned_config_params = config_params.clone();
-                let circuit = RecursionCircuit::new(
-                    CircuitBuilderStage::Prover,
-                    &params,
-                    cloned_voter_snark.clone(),
-                    cloned_state_transition_snark.clone(),
-                    RecursionCircuit::initial_snark(
-                        &params,
-                        None,
-                        cloned_config_params.clone(),
-                        base_instances.clone(),
-                    ),
-                    0,
-                    cloned_config_params,
-                );
+//     let mut group = c.benchmark_group("plonk-prover");
+//     group.sample_size(10);
+//     group.bench_with_input(
+//         BenchmarkId::new("wrapper circuit", K),
+//         &(
+//             &recursion_params,
+//             &pk,
+//             &voter_snark,
+//             &state_transition_snark,
+//         ),
+//         |bencher, &(params, pk, voter_snark, state_transition_snark)| {
+//             let cloned_voter_snark = voter_snark;
+//             let cloned_state_transition_snark = state_transition_snark;
+//             bencher.iter(|| {
+//                 let cloned_config_params = config_params.clone();
+//                 let circuit = RecursionCircuit::new(
+//                     CircuitBuilderStage::Prover,
+//                     &params,
+//                     cloned_voter_snark.clone(),
+//                     cloned_state_transition_snark.clone(),
+//                     RecursionCircuit::initial_snark(
+//                         &params,
+//                         None,
+//                         cloned_config_params.clone(),
+//                         base_instances.clone(),
+//                     ),
+//                     0,
+//                     cloned_config_params,
+//                 );
 
-                gen_proof(params, pk, circuit);
-            })
-        },
-    );
-    group.finish()
-}
+//                 gen_proof(params, pk, circuit);
+//             })
+//         },
+//     );
+//     group.finish()
+// }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
-    targets = bench
-}
-criterion_main!(benches);
+// criterion_group! {
+//     name = benches;
+//     config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
+//     targets = bench
+// }
+// criterion_main!(benches);
+fn main() {}

--- a/aggregator/benches/wrapper_circuit.rs
+++ b/aggregator/benches/wrapper_circuit.rs
@@ -1,21 +1,21 @@
-// use aggregator::state_transition::StateTransitionCircuit;
 // use aggregator::utils::generate_wrapper_circuit_input;
 // use aggregator::wrapper::common::gen_dummy_snark;
 // use aggregator::wrapper::common::gen_pk;
+// use aggregator::wrapper::common::gen_proof;
 // use aggregator::wrapper::common::gen_snark;
 // use aggregator::wrapper::recursion::RecursionCircuit;
 // use halo2_base::gates::circuit::BaseCircuitParams;
 // use halo2_base::gates::circuit::CircuitBuilderStage;
+// use halo2_base::halo2_proofs::dev::MockProver;
+// use halo2_base::halo2_proofs::{halo2curves::bn256::Fr, plonk::*};
+// use halo2_base::utils::decompose_biguint;
 // use halo2_base::utils::fs::gen_srs;
-// use halo2_base::{
-//     halo2_proofs::{halo2curves::bn256::Fr, plonk::*},
-//     utils::testing::gen_proof,
-// };
 
 // use criterion::{criterion_group, criterion_main};
 // use criterion::{BenchmarkId, Criterion};
 
 // use pprof::criterion::{Output, PProfProfiler};
+// use snark_verifier_sdk::CircuitExt;
 // use voter::VoterCircuit;
 
 // const K: u32 = 22;
@@ -37,27 +37,6 @@
 //     let voter_pk = gen_pk(&voter_params, &voter_circuit);
 //     let voter_snark = gen_snark(&voter_params, &voter_pk, voter_circuit);
 
-//     // Generating state transition proof
-//     let state_transition_config = BaseCircuitParams {
-//         k: 15,
-//         num_advice_per_phase: vec![3],
-//         num_lookup_advice_per_phase: vec![1, 0, 0],
-//         num_fixed: 1,
-//         lookup_bits: Some(14),
-//         num_instance_columns: 1,
-//     };
-//     let state_transition_params = gen_srs(15);
-//     let state_transition_circuit = StateTransitionCircuit::new(
-//         state_transition_config.clone(),
-//         state_transition_inputs[0].clone(),
-//     );
-//     let state_transition_pk = gen_pk(&state_transition_params, &state_transition_circuit);
-//     let state_transition_snark = gen_snark(
-//         &state_transition_params,
-//         &state_transition_pk,
-//         state_transition_circuit,
-//     );
-
 //     let recursion_config = BaseCircuitParams {
 //         k: K as usize,
 //         num_advice_per_phase: vec![4],
@@ -68,6 +47,11 @@
 //     };
 //     let recursion_params = gen_srs(K);
 
+//     let mut init_vote = Vec::<Fr>::new();
+//     for x in state_transition_inputs[0].prev_vote.iter() {
+//         init_vote.extend(decompose_biguint::<Fr>(x, 4, 88));
+//     }
+
 //     // Init Base Instances
 //     let mut base_instances = [
 //         Fr::zero(),                  // preprocessed_digest
@@ -77,24 +61,19 @@
 //         voter_snark.instances[0][3],
 //     ]
 //     .to_vec();
-//     base_instances.extend(state_transition_snark.instances[0][4..24].iter()); // init_vote
+//     base_instances.extend(init_vote); // init_vote
 //     base_instances.extend([
-//         state_transition_snark.instances[0][68], // nullifier_old_root
-//         state_transition_snark.instances[0][68], // nullifier_new_root
-//         voter_snark.instances[0][28],            // membership_root
-//         voter_snark.instances[0][29],            // proposal_id
-//         Fr::from(0),                             // round
+//         state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_old_root
+//         state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_new_root
+//         voter_snark.instances[0][28],                             // membership_root
+//         voter_snark.instances[0][29],                             // proposal_id
+//         Fr::from(0),                                              // round
 //     ]);
 
 //     let recursion_circuit = RecursionCircuit::new(
 //         CircuitBuilderStage::Keygen,
 //         &recursion_params,
 //         gen_dummy_snark::<VoterCircuit<Fr>>(&voter_params, Some(voter_pk.get_vk()), voter_config),
-//         gen_dummy_snark::<StateTransitionCircuit<Fr>>(
-//             &state_transition_params,
-//             Some(state_transition_pk.get_vk()),
-//             state_transition_config,
-//         ),
 //         RecursionCircuit::initial_snark(
 //             &recursion_params,
 //             None,
@@ -103,6 +82,7 @@
 //         ),
 //         0,
 //         recursion_config,
+//         state_transition_inputs[0].clone(),
 //     );
 //     let pk = gen_pk(&recursion_params, &recursion_circuit);
 //     let config_params = recursion_circuit.inner().params();
@@ -111,22 +91,16 @@
 //     group.sample_size(10);
 //     group.bench_with_input(
 //         BenchmarkId::new("wrapper circuit", K),
-//         &(
-//             &recursion_params,
-//             &pk,
-//             &voter_snark,
-//             &state_transition_snark,
-//         ),
-//         |bencher, &(params, pk, voter_snark, state_transition_snark)| {
+//         &(&recursion_params, &pk, &voter_snark),
+//         |bencher, &(params, pk, voter_snark)| {
 //             let cloned_voter_snark = voter_snark;
-//             let cloned_state_transition_snark = state_transition_snark;
 //             bencher.iter(|| {
 //                 let cloned_config_params = config_params.clone();
 //                 let circuit = RecursionCircuit::new(
-//                     CircuitBuilderStage::Prover,
+//                     CircuitBuilderStage::Prover
+//                     ,
 //                     &params,
 //                     cloned_voter_snark.clone(),
-//                     cloned_state_transition_snark.clone(),
 //                     RecursionCircuit::initial_snark(
 //                         &params,
 //                         None,
@@ -135,9 +109,12 @@
 //                     ),
 //                     0,
 //                     cloned_config_params,
+//                     state_transition_inputs[0].clone(),
 //                 );
-
-//                 gen_proof(params, pk, circuit);
+//                 println!("reached proof generation");
+//                 let instances = circuit.inner().instances().clone();
+//                 gen_proof(params, pk, circuit, instances);
+//                 println!("completed proof generation")
 //             })
 //         },
 //     );

--- a/aggregator/benches/wrapper_circuit.rs
+++ b/aggregator/benches/wrapper_circuit.rs
@@ -1,130 +1,125 @@
-// use aggregator::utils::generate_wrapper_circuit_input;
-// use aggregator::wrapper::common::gen_dummy_snark;
-// use aggregator::wrapper::common::gen_pk;
-// use aggregator::wrapper::common::gen_proof;
-// use aggregator::wrapper::common::gen_snark;
-// use aggregator::wrapper::recursion::RecursionCircuit;
-// use halo2_base::gates::circuit::BaseCircuitParams;
-// use halo2_base::gates::circuit::CircuitBuilderStage;
-// use halo2_base::halo2_proofs::dev::MockProver;
-// use halo2_base::halo2_proofs::{halo2curves::bn256::Fr, plonk::*};
-// use halo2_base::utils::decompose_biguint;
-// use halo2_base::utils::fs::gen_srs;
+use aggregator::utils::generate_wrapper_circuit_input;
+use aggregator::wrapper::common::gen_dummy_snark;
+use aggregator::wrapper::common::gen_pk;
+use aggregator::wrapper::common::gen_proof;
+use aggregator::wrapper::common::gen_snark;
+use aggregator::wrapper::recursion::RecursionCircuit;
+use halo2_base::gates::circuit::BaseCircuitParams;
+use halo2_base::halo2_proofs::{halo2curves::bn256::Fr, plonk::*};
+use halo2_base::utils::decompose_biguint;
+use halo2_base::utils::fs::gen_srs;
 
-// use criterion::{criterion_group, criterion_main};
-// use criterion::{BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion};
 
-// use pprof::criterion::{Output, PProfProfiler};
-// use snark_verifier_sdk::CircuitExt;
-// use voter::VoterCircuit;
+use pprof::criterion::{Output, PProfProfiler};
+use snark_verifier_sdk::CircuitExt;
+use voter::VoterCircuit;
 
-// const K: u32 = 22;
+const K: u32 = 22;
 
-// fn bench(c: &mut Criterion) {
-//     let (voter_inputs, state_transition_inputs) = generate_wrapper_circuit_input(1);
+fn bench(c: &mut Criterion) {
+    let (voter_inputs, state_transition_inputs) = generate_wrapper_circuit_input(1);
 
-//     // Generating voter proof
-//     let voter_config = BaseCircuitParams {
-//         k: 15,
-//         num_advice_per_phase: vec![1],
-//         num_lookup_advice_per_phase: vec![1, 0, 0],
-//         num_fixed: 1,
-//         lookup_bits: Some(14),
-//         num_instance_columns: 1,
-//     };
-//     let voter_params = gen_srs(15);
-//     let voter_circuit = VoterCircuit::new(voter_config.clone(), voter_inputs[0].clone());
-//     let voter_pk = gen_pk(&voter_params, &voter_circuit);
-//     let voter_snark = gen_snark(&voter_params, &voter_pk, voter_circuit);
+    // Generating voter proof
+    let voter_config = BaseCircuitParams {
+        k: 15,
+        num_advice_per_phase: vec![1],
+        num_lookup_advice_per_phase: vec![1, 0, 0],
+        num_fixed: 1,
+        lookup_bits: Some(14),
+        num_instance_columns: 1,
+    };
+    let voter_params = gen_srs(15);
+    let voter_circuit = VoterCircuit::new(voter_config.clone(), voter_inputs[0].clone());
+    let voter_pk = gen_pk(&voter_params, &voter_circuit);
+    let voter_snark = gen_snark(&voter_params, &voter_pk, voter_circuit);
 
-//     let recursion_config = BaseCircuitParams {
-//         k: K as usize,
-//         num_advice_per_phase: vec![4],
-//         num_lookup_advice_per_phase: vec![1, 0, 0],
-//         num_fixed: 1,
-//         lookup_bits: Some((K - 1) as usize),
-//         num_instance_columns: 1,
-//     };
-//     let recursion_params = gen_srs(K);
+    let recursion_config = BaseCircuitParams {
+        k: K as usize,
+        num_advice_per_phase: vec![4],
+        num_lookup_advice_per_phase: vec![1, 0, 0],
+        num_fixed: 1,
+        lookup_bits: Some((K - 1) as usize),
+        num_instance_columns: 1,
+    };
+    let recursion_params = gen_srs(K);
 
-//     let mut init_vote = Vec::<Fr>::new();
-//     for x in state_transition_inputs[0].prev_vote.iter() {
-//         init_vote.extend(decompose_biguint::<Fr>(x, 4, 88));
-//     }
+    let mut init_vote = Vec::<Fr>::new();
+    for x in state_transition_inputs[0].prev_vote.iter() {
+        init_vote.extend(decompose_biguint::<Fr>(x, 4, 88));
+    }
 
-//     // Init Base Instances
-//     let mut base_instances = [
-//         Fr::zero(),                  // preprocessed_digest
-//         voter_snark.instances[0][0], // pk_enc_n
-//         voter_snark.instances[0][1],
-//         voter_snark.instances[0][2], // pk_enc_g
-//         voter_snark.instances[0][3],
-//     ]
-//     .to_vec();
-//     base_instances.extend(init_vote); // init_vote
-//     base_instances.extend([
-//         state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_old_root
-//         state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_new_root
-//         voter_snark.instances[0][28],                             // membership_root
-//         voter_snark.instances[0][29],                             // proposal_id
-//         Fr::from(0),                                              // round
-//     ]);
+    // Init Base Instances
+    let mut base_instances = [
+        Fr::zero(),                  // preprocessed_digest
+        voter_snark.instances[0][0], // pk_enc_n
+        voter_snark.instances[0][1],
+        voter_snark.instances[0][2], // pk_enc_g
+        voter_snark.instances[0][3],
+    ]
+    .to_vec();
+    base_instances.extend(init_vote); // init_vote
+    base_instances.extend([
+        state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_old_root
+        state_transition_inputs[0].nullifier_tree.get_old_root(), // nullifier_new_root
+        voter_snark.instances[0][28],                             // membership_root
+        voter_snark.instances[0][29],                             // proposal_id
+        Fr::from(0),                                              // round
+    ]);
 
-//     let recursion_circuit = RecursionCircuit::new(
-//         CircuitBuilderStage::Keygen,
-//         &recursion_params,
-//         gen_dummy_snark::<VoterCircuit<Fr>>(&voter_params, Some(voter_pk.get_vk()), voter_config),
-//         RecursionCircuit::initial_snark(
-//             &recursion_params,
-//             None,
-//             recursion_config.clone(),
-//             base_instances.clone(),
-//         ),
-//         0,
-//         recursion_config,
-//         state_transition_inputs[0].clone(),
-//     );
-//     let pk = gen_pk(&recursion_params, &recursion_circuit);
-//     let config_params = recursion_circuit.inner().params();
+    let recursion_circuit = RecursionCircuit::new(
+        &recursion_params,
+        gen_dummy_snark::<VoterCircuit<Fr>>(&voter_params, Some(voter_pk.get_vk()), voter_config),
+        RecursionCircuit::initial_snark(
+            &recursion_params,
+            None,
+            recursion_config.clone(),
+            base_instances.clone(),
+        ),
+        0,
+        recursion_config,
+        state_transition_inputs[0].clone(),
+    );
+    let pk = gen_pk(&recursion_params, &recursion_circuit);
+    let config_params = recursion_circuit.inner().params();
 
-//     let mut group = c.benchmark_group("plonk-prover");
-//     group.sample_size(10);
-//     group.bench_with_input(
-//         BenchmarkId::new("wrapper circuit", K),
-//         &(&recursion_params, &pk, &voter_snark),
-//         |bencher, &(params, pk, voter_snark)| {
-//             let cloned_voter_snark = voter_snark;
-//             bencher.iter(|| {
-//                 let cloned_config_params = config_params.clone();
-//                 let circuit = RecursionCircuit::new(
-//                     CircuitBuilderStage::Prover
-//                     ,
-//                     &params,
-//                     cloned_voter_snark.clone(),
-//                     RecursionCircuit::initial_snark(
-//                         &params,
-//                         None,
-//                         cloned_config_params.clone(),
-//                         base_instances.clone(),
-//                     ),
-//                     0,
-//                     cloned_config_params,
-//                     state_transition_inputs[0].clone(),
-//                 );
-//                 println!("reached proof generation");
-//                 let instances = circuit.inner().instances().clone();
-//                 gen_proof(params, pk, circuit, instances);
-//                 println!("completed proof generation")
-//             })
-//         },
-//     );
-//     group.finish()
-// }
+    let mut group = c.benchmark_group("plonk-prover");
+    group.sample_size(10);
 
-// criterion_group! {
-//     name = benches;
-//     config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
-//     targets = bench
-// }
-// criterion_main!(benches);
-fn main() {}
+    group.bench_with_input(
+        BenchmarkId::new("wrapper circuit", K),
+        &(&recursion_params, &pk, &voter_snark),
+        |bencher, &(params, pk, voter_snark)| {
+            let cloned_voter_snark = voter_snark;
+            bencher.iter(|| {
+                let cloned_config_params = config_params.clone();
+                let circuit = RecursionCircuit::new(
+                    &params,
+                    cloned_voter_snark.clone(),
+                    RecursionCircuit::initial_snark(
+                        &params,
+                        None,
+                        cloned_config_params.clone(),
+                        base_instances.clone(),
+                    ),
+                    0,
+                    cloned_config_params,
+                    state_transition_inputs[0].clone(),
+                );
+                println!("reached proof generation");
+                let instances = circuit.inner().instances().clone();
+                gen_proof(params, pk, circuit, instances);
+                println!("completed proof generation")
+            })
+        },
+    );
+    group.finish()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(10, Output::Flamegraph(None)));
+    targets = bench
+}
+criterion_main!(benches);

--- a/aggregator/src/state_transition.rs
+++ b/aggregator/src/state_transition.rs
@@ -1,26 +1,27 @@
 use halo2_base::gates::circuit::builder::BaseCircuitBuilder;
-use halo2_base::gates::circuit::{BaseCircuitParams, BaseConfig};
+use halo2_base::gates::circuit::{ BaseCircuitParams, BaseConfig };
 use halo2_base::gates::GateInstructions;
-use halo2_base::halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
-use halo2_base::halo2_proofs::plonk::{Circuit, ConstraintSystem, Error};
-use halo2_base::poseidon::hasher::{spec::OptimizedPoseidonSpec, PoseidonHasher};
+use halo2_base::halo2_proofs::circuit::{ Layouter, SimpleFloorPlanner };
+use halo2_base::halo2_proofs::plonk::{ Circuit, ConstraintSystem, Error };
+use halo2_base::poseidon::hasher::{ spec::OptimizedPoseidonSpec, PoseidonHasher };
 use halo2_base::{
-    gates::{RangeChip, RangeInstructions},
+    gates::{ RangeChip, RangeInstructions },
     halo2_proofs::circuit::Value,
     utils::BigPrimeField,
-    AssignedValue, Context,
+    AssignedValue,
+    Context,
 };
 use halo2_ecc::ecc::EccChip;
 use halo2_ecc::fields::fp::FpChip;
-use indexed_merkle_tree_halo2::indexed_merkle_tree::{insert_leaf, IndexedMerkleTreeLeaf};
+use indexed_merkle_tree_halo2::indexed_merkle_tree::{ insert_leaf, IndexedMerkleTreeLeaf };
 use indexed_merkle_tree_halo2::utils::IndexedMerkleTreeLeaf as IMTLeaf;
 use num_bigint::BigUint;
 
 use biguint_halo2::big_uint::chip::BigUintChip;
-use halo2_base::halo2_proofs::halo2curves::secp256k1::{Fp, Secp256k1Affine};
-use paillier_chip::paillier::{EncryptionPublicKeyAssigned, PaillierChip};
-use serde::{Deserialize, Serialize};
-use voter::{compress_nullifier, CircuitExt, EncryptionPublicKey};
+use halo2_base::halo2_proofs::halo2curves::secp256k1::{ Fp, Secp256k1Affine };
+use paillier_chip::paillier::{ EncryptionPublicKeyAssigned, PaillierChip };
+use serde::{ Deserialize, Serialize };
+use voter::{ compress_nullifier, CircuitExt, EncryptionPublicKey };
 
 const ENC_BIT_LEN: usize = 176;
 const LIMB_BIT_LEN: usize = 88;
@@ -52,7 +53,7 @@ impl<F: BigPrimeField> IndexedMerkleTreeInput<F> {
         new_leaf_index: F,
         new_leaf_proof: Vec<F>,
         new_leaf_proof_helper: Vec<F>,
-        is_new_leaf_largest: F,
+        is_new_leaf_largest: F
     ) -> Self {
         Self {
             old_root,
@@ -66,6 +67,9 @@ impl<F: BigPrimeField> IndexedMerkleTreeInput<F> {
             new_leaf_proof_helper,
             is_new_leaf_largest,
         }
+    }
+    pub fn get_old_root(&self) -> F {
+        self.old_root
     }
 }
 
@@ -83,7 +87,7 @@ impl<F: BigPrimeField> StateTransitionInput<F> {
         incoming_vote: Vec<BigUint>,
         prev_vote: Vec<BigUint>,
         nullifier_tree: IndexedMerkleTreeInput<F>,
-        nullifier: Secp256k1Affine,
+        nullifier: Secp256k1Affine
     ) -> Self {
         Self {
             pk_enc,
@@ -99,7 +103,7 @@ pub fn state_transition_circuit<F: BigPrimeField>(
     ctx: &mut Context<F>,
     range: &RangeChip<F>,
     input: StateTransitionInput<F>,
-    public_inputs: &mut Vec<AssignedValue<F>>,
+    public_inputs: &mut Vec<AssignedValue<F>>
 ) {
     let gate = range.gate();
     let mut hasher = PoseidonHasher::<F, 3, 2>::new(OptimizedPoseidonSpec::new::<8, 57, 0>());
@@ -128,22 +132,16 @@ pub fn state_transition_circuit<F: BigPrimeField>(
         g: g_assigned,
     };
 
-    let incoming_vote = input
-        .incoming_vote
+    let incoming_vote = input.incoming_vote
         .iter()
         .map(|x| {
-            biguint_chip
-                .assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2)
-                .unwrap()
+            biguint_chip.assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2).unwrap()
         })
         .collect::<Vec<_>>();
-    let prev_vote = input
-        .prev_vote
+    let prev_vote = input.prev_vote
         .iter()
         .map(|x| {
-            biguint_chip
-                .assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2)
-                .unwrap()
+            biguint_chip.assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2).unwrap()
         })
         .collect::<Vec<_>>();
 
@@ -175,27 +173,19 @@ pub fn state_transition_circuit<F: BigPrimeField>(
     let new_leaf_index = ctx.load_witness(input.nullifier_tree.new_leaf_index);
     let is_new_leaf_largest = ctx.load_witness(input.nullifier_tree.is_new_leaf_largest);
 
-    let low_leaf_proof = input
-        .nullifier_tree
-        .low_leaf_proof
+    let low_leaf_proof = input.nullifier_tree.low_leaf_proof
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let low_leaf_proof_helper = input
-        .nullifier_tree
-        .low_leaf_proof_helper
+    let low_leaf_proof_helper = input.nullifier_tree.low_leaf_proof_helper
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let new_leaf_proof = input
-        .nullifier_tree
-        .new_leaf_proof
+    let new_leaf_proof = input.nullifier_tree.new_leaf_proof
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let new_leaf_proof_helper = input
-        .nullifier_tree
-        .new_leaf_proof_helper
+    let new_leaf_proof_helper = input.nullifier_tree.new_leaf_proof_helper
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
@@ -213,7 +203,7 @@ pub fn state_transition_circuit<F: BigPrimeField>(
         &new_leaf_index,
         &new_leaf_proof,
         &new_leaf_proof_helper,
-        &is_new_leaf_largest,
+        &is_new_leaf_largest
     );
 
     // PK_ENC N
@@ -300,10 +290,12 @@ impl<F: BigPrimeField> CircuitExt<F> for StateTransitionCircuit<F> {
     }
 
     fn instances(&self) -> Vec<Vec<F>> {
-        vec![self.inner.assigned_instances[0]
-            .iter()
-            .map(|instance| *instance.value())
-            .collect()]
+        vec![
+            self.inner.assigned_instances[0]
+                .iter()
+                .map(|instance| *instance.value())
+                .collect()
+        ]
     }
 }
 
@@ -311,7 +303,7 @@ impl<F: BigPrimeField> CircuitExt<F> for StateTransitionCircuit<F> {
 mod test {
     use halo2_base::{
         gates::circuit::BaseCircuitParams,
-        halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr},
+        halo2_proofs::{ dev::MockProver, halo2curves::bn256::Fr },
         utils::testing::base_test,
         AssignedValue,
     };
@@ -319,7 +311,7 @@ mod test {
 
     use crate::utils::generate_wrapper_circuit_input;
 
-    use super::{state_transition_circuit, StateTransitionCircuit};
+    use super::{ state_transition_circuit, StateTransitionCircuit };
 
     #[test]
     fn test_state_transition_circuit() {

--- a/aggregator/src/state_transition.rs
+++ b/aggregator/src/state_transition.rs
@@ -1,32 +1,24 @@
-use halo2_base::gates::circuit::builder::BaseCircuitBuilder;
-use halo2_base::gates::circuit::{ BaseCircuitParams, BaseConfig };
-use halo2_base::gates::GateInstructions;
-use halo2_base::halo2_proofs::circuit::{ Layouter, SimpleFloorPlanner };
-use halo2_base::halo2_proofs::plonk::{ Circuit, ConstraintSystem, Error };
-use halo2_base::poseidon::hasher::{ spec::OptimizedPoseidonSpec, PoseidonHasher };
+use biguint_halo2::big_uint::chip::BigUintChip;
+use biguint_halo2::big_uint::{AssignedBigUint, Fresh};
+use halo2_base::halo2_proofs::halo2curves::secp256k1::Secp256k1Affine;
+use halo2_base::poseidon::hasher::{spec::OptimizedPoseidonSpec, PoseidonHasher};
+use halo2_base::utils::fe_to_biguint;
 use halo2_base::{
-    gates::{ RangeChip, RangeInstructions },
+    gates::{RangeChip, RangeInstructions},
     halo2_proofs::circuit::Value,
     utils::BigPrimeField,
-    AssignedValue,
-    Context,
+    AssignedValue, Context,
 };
-use halo2_ecc::ecc::EccChip;
-use halo2_ecc::fields::fp::FpChip;
-use indexed_merkle_tree_halo2::indexed_merkle_tree::{ insert_leaf, IndexedMerkleTreeLeaf };
+use halo2_ecc::bigint::OverflowInteger;
+use indexed_merkle_tree_halo2::indexed_merkle_tree::{insert_leaf, IndexedMerkleTreeLeaf};
 use indexed_merkle_tree_halo2::utils::IndexedMerkleTreeLeaf as IMTLeaf;
 use num_bigint::BigUint;
-
-use biguint_halo2::big_uint::chip::BigUintChip;
-use halo2_base::halo2_proofs::halo2curves::secp256k1::{ Fp, Secp256k1Affine };
-use paillier_chip::paillier::{ EncryptionPublicKeyAssigned, PaillierChip };
-use serde::{ Deserialize, Serialize };
-use voter::{ compress_nullifier, CircuitExt, EncryptionPublicKey };
+use paillier_chip::paillier::{EncryptionPublicKeyAssigned, PaillierChip};
+use serde::{Deserialize, Serialize};
+use voter::EncryptionPublicKey;
 
 const ENC_BIT_LEN: usize = 176;
 const LIMB_BIT_LEN: usize = 88;
-
-//TODO: Constrain the nullifier hash using x and y limbs
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexedMerkleTreeInput<F: BigPrimeField> {
@@ -53,7 +45,7 @@ impl<F: BigPrimeField> IndexedMerkleTreeInput<F> {
         new_leaf_index: F,
         new_leaf_proof: Vec<F>,
         new_leaf_proof_helper: Vec<F>,
-        is_new_leaf_largest: F
+        is_new_leaf_largest: F,
     ) -> Self {
         Self {
             old_root,
@@ -75,7 +67,12 @@ impl<F: BigPrimeField> IndexedMerkleTreeInput<F> {
         self.new_root
     }
 }
-
+fn limbs_to_biguint<F: BigPrimeField>(x: Vec<F>) -> BigUint {
+    x.iter()
+        .enumerate()
+        .map(|(i, limb)| fe_to_biguint(limb) * BigUint::from(2u64).pow(88 * (i as u32)))
+        .sum()
+}
 #[derive(Debug, Clone)]
 pub struct StateTransitionInput<F: BigPrimeField> {
     pub pk_enc: EncryptionPublicKey,
@@ -90,7 +87,7 @@ impl<F: BigPrimeField> StateTransitionInput<F> {
         incoming_vote: Vec<BigUint>,
         prev_vote: Vec<BigUint>,
         nullifier_tree: IndexedMerkleTreeInput<F>,
-        nullifier: Secp256k1Affine
+        nullifier: Secp256k1Affine,
     ) -> Self {
         Self {
             pk_enc,
@@ -105,8 +102,9 @@ impl<F: BigPrimeField> StateTransitionInput<F> {
 pub fn state_transition_circuit<F: BigPrimeField>(
     ctx: &mut Context<F>,
     range: &RangeChip<F>,
-    input: StateTransitionInput<F>,
-    public_inputs: &mut Vec<AssignedValue<F>>
+    nullifier_tree: IndexedMerkleTreeInput<F>,
+    input_vec: Vec<AssignedValue<F>>,
+    public_inputs: &mut Vec<AssignedValue<F>>,
 ) {
     let gate = range.gate();
     let mut hasher = PoseidonHasher::<F, 3, 2>::new(OptimizedPoseidonSpec::new::<8, 57, 0>());
@@ -115,38 +113,72 @@ pub fn state_transition_circuit<F: BigPrimeField>(
     let biguint_chip = BigUintChip::construct(range, LIMB_BIT_LEN);
     let paillier_chip = PaillierChip::construct(&biguint_chip, ENC_BIT_LEN);
 
-    let fp_chip = FpChip::<F, Fp>::new(range, LIMB_BIT_LEN, 3);
-    let ecc_chip = EccChip::<F, FpChip<F, Fp>>::new(&fp_chip);
+    let nullifier_hash = hasher.hash_fix_len_array(ctx, gate, &input_vec[0..4]);
 
-    let nullifier = ecc_chip.load_private_unchecked(ctx, (input.nullifier.x, input.nullifier.y));
-    let compressed_nullifier = compress_nullifier(ctx, range, &nullifier);
-    let nullifier_hash = hasher.hash_fix_len_array(ctx, gate, &compressed_nullifier);
-
-    let n_assigned = biguint_chip
-        .assign_integer(ctx, Value::known(input.pk_enc.n.clone()), ENC_BIT_LEN)
-        .unwrap();
-
-    let g_assigned = biguint_chip
-        .assign_integer(ctx, Value::known(input.pk_enc.g.clone()), ENC_BIT_LEN)
-        .unwrap();
+    let n_fr = input_vec[4..6]
+        .iter()
+        .map(|vote| *vote.value())
+        .collect::<Vec<F>>();
+    let n_assigned = AssignedBigUint::<F, Fresh>::new(
+        OverflowInteger::new(input_vec[4..6].to_vec(), 88),
+        Value::known(limbs_to_biguint(n_fr)),
+    );
+    let g_fr = input_vec[6..8]
+        .iter()
+        .map(|vote| *vote.value())
+        .collect::<Vec<F>>();
+    let g_assigned = AssignedBigUint::<F, Fresh>::new(
+        OverflowInteger::new(input_vec[6..8].to_vec(), 88),
+        Value::known(limbs_to_biguint(g_fr)),
+    );
 
     let pk_enc = EncryptionPublicKeyAssigned {
         n: n_assigned,
         g: g_assigned,
     };
+    let incoming_vote_fr: Vec<F> = input_vec[8..28].iter().map(|x| *x.value()).collect();
+    let incoming_vote_biguint = incoming_vote_fr
+        .chunks(4)
+        .into_iter()
+        .map(|chunk| limbs_to_biguint(chunk.to_vec()))
+        .collect::<Vec<BigUint>>();
+    let incoming_vote_overflow_int = input_vec[8..28]
+        .chunks(4)
+        .into_iter()
+        .map(|chunk| OverflowInteger::new(chunk.to_vec(), 88))
+        .collect::<Vec<OverflowInteger<F>>>();
+    let incoming_vote = incoming_vote_overflow_int
+        .iter()
+        .enumerate()
+        .map(|(i, over_flow)| {
+            AssignedBigUint::new(
+                over_flow.clone(),
+                Value::known(incoming_vote_biguint[i].clone()),
+            )
+        })
+        .collect::<Vec<AssignedBigUint<F, Fresh>>>();
 
-    let incoming_vote = input.incoming_vote
+    let prev_vote_fr: Vec<F> = input_vec[28..48].iter().map(|x| *x.value()).collect();
+    let prev_vote_biguint = prev_vote_fr
+        .chunks(4)
+        .into_iter()
+        .map(|chunk| limbs_to_biguint(chunk.to_vec()))
+        .collect::<Vec<BigUint>>();
+    let prev_vote_overflow_int = input_vec[28..48]
+        .chunks(4)
+        .into_iter()
+        .map(|chunk| OverflowInteger::new(chunk.to_vec(), 88))
+        .collect::<Vec<OverflowInteger<F>>>();
+    let prev_vote = prev_vote_overflow_int
         .iter()
-        .map(|x| {
-            biguint_chip.assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2).unwrap()
+        .enumerate()
+        .map(|(i, over_flow)| {
+            AssignedBigUint::new(
+                over_flow.clone(),
+                Value::known(prev_vote_biguint[i].clone()),
+            )
         })
-        .collect::<Vec<_>>();
-    let prev_vote = input.prev_vote
-        .iter()
-        .map(|x| {
-            biguint_chip.assign_integer(ctx, Value::known(x.clone()), ENC_BIT_LEN * 2).unwrap()
-        })
-        .collect::<Vec<_>>();
+        .collect::<Vec<AssignedBigUint<F, Fresh>>>();
 
     // Step 1: Aggregate the votes
     let aggr_vote = incoming_vote
@@ -156,194 +188,70 @@ pub fn state_transition_circuit<F: BigPrimeField>(
         .collect::<Vec<_>>();
 
     // Step 2: Update the nullifier tree
-    let val = ctx.load_witness(input.nullifier_tree.low_leaf.val);
-    let next_val = ctx.load_witness(input.nullifier_tree.low_leaf.next_val);
-    let next_idx = ctx.load_witness(input.nullifier_tree.low_leaf.next_idx);
+    let val = ctx.load_witness(nullifier_tree.low_leaf.val);
+    let next_val = ctx.load_witness(nullifier_tree.low_leaf.next_val);
+    let next_idx = ctx.load_witness(nullifier_tree.low_leaf.next_idx);
 
-    let old_root = ctx.load_witness(input.nullifier_tree.old_root);
+    let old_root = ctx.load_witness(nullifier_tree.old_root);
     let low_leaf = IndexedMerkleTreeLeaf::new(val, next_val, next_idx);
 
-    let new_root = ctx.load_witness(input.nullifier_tree.new_root);
+    let new_root = ctx.load_witness(nullifier_tree.new_root);
 
-    let val = ctx.load_witness(input.nullifier_tree.new_leaf.val);
-    assert_eq!(val.value(), nullifier_hash.value());
+    let val = ctx.load_witness(nullifier_tree.new_leaf.val);
+    //assert_eq!(val.value(), nullifier_hash.value());
     ctx.constrain_equal(&val, &nullifier_hash);
-    let next_val = ctx.load_witness(input.nullifier_tree.new_leaf.next_val);
-    let next_idx = ctx.load_witness(input.nullifier_tree.new_leaf.next_idx);
+    let next_val = ctx.load_witness(nullifier_tree.new_leaf.next_val);
+    let next_idx = ctx.load_witness(nullifier_tree.new_leaf.next_idx);
 
     let new_leaf = IndexedMerkleTreeLeaf::new(val, next_val, next_idx);
 
-    let new_leaf_index = ctx.load_witness(input.nullifier_tree.new_leaf_index);
-    let is_new_leaf_largest = ctx.load_witness(input.nullifier_tree.is_new_leaf_largest);
+    let new_leaf_index = ctx.load_witness(nullifier_tree.new_leaf_index);
+    let is_new_leaf_largest = ctx.load_witness(nullifier_tree.is_new_leaf_largest);
 
-    let low_leaf_proof = input.nullifier_tree.low_leaf_proof
+    let low_leaf_proof = nullifier_tree
+        .low_leaf_proof
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let low_leaf_proof_helper = input.nullifier_tree.low_leaf_proof_helper
+    let low_leaf_proof_helper = nullifier_tree
+        .low_leaf_proof_helper
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let new_leaf_proof = input.nullifier_tree.new_leaf_proof
+    let new_leaf_proof = nullifier_tree
+        .new_leaf_proof
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
-    let new_leaf_proof_helper = input.nullifier_tree.new_leaf_proof_helper
+    let new_leaf_proof_helper = nullifier_tree
+        .new_leaf_proof_helper
         .iter()
         .map(|x| ctx.load_witness(*x))
         .collect::<Vec<_>>();
 
-    insert_leaf::<F, 3, 2>(
-        ctx,
-        range,
-        &hasher,
-        &old_root,
-        &low_leaf,
-        &low_leaf_proof,
-        &low_leaf_proof_helper,
-        &new_root,
-        &new_leaf,
-        &new_leaf_index,
-        &new_leaf_proof,
-        &new_leaf_proof_helper,
-        &is_new_leaf_largest
-    );
+    // insert_leaf::<F, 3, 2>(
+    //     ctx,
+    //     range,
+    //     &hasher,
+    //     &old_root,
+    //     &low_leaf,
+    //     &low_leaf_proof,
+    //     &low_leaf_proof_helper,
+    //     &new_root,
+    //     &new_leaf,
+    //     &new_leaf_index,
+    //     &new_leaf_proof,
+    //     &new_leaf_proof_helper,
+    //     &is_new_leaf_largest,
+    // );
 
-    // PK_ENC N
-    public_inputs.extend(pk_enc.n.limbs());
-
-    // PK_ENC G
-    public_inputs.extend(pk_enc.g.limbs());
-
-    // PREV_VOTE
-    for enc_vote in prev_vote {
-        public_inputs.extend(enc_vote.limbs());
-    }
-
-    // INCOMING_VOTE
-    for enc_vote in incoming_vote {
-        public_inputs.extend(enc_vote.limbs());
-    }
-
-    // AGGR_VOTE
     for enc_vote in aggr_vote {
         public_inputs.extend(enc_vote.limbs());
     }
-
-    // NULLIFIER
-    public_inputs.extend(compressed_nullifier);
 
     // NULLIFIER_OLD_ROOT
     public_inputs.extend([old_root]);
 
     // NULLIFIER_NEW_ROOT
     public_inputs.extend([new_root]);
-}
-
-pub struct StateTransitionCircuit<F: BigPrimeField> {
-    input: StateTransitionInput<F>,
-    pub inner: BaseCircuitBuilder<F>,
-}
-
-impl<F: BigPrimeField> StateTransitionCircuit<F> {
-    pub fn new(config: BaseCircuitParams, input: StateTransitionInput<F>) -> Self {
-        let mut inner = BaseCircuitBuilder::default();
-        inner.set_params(config);
-
-        let range = inner.range_chip();
-        let ctx = inner.main(0);
-
-        let mut public_inputs = Vec::<AssignedValue<F>>::new();
-        state_transition_circuit(ctx, &range, input.clone(), &mut public_inputs);
-        inner.assigned_instances[0].extend(public_inputs);
-        inner.calculate_params(Some(10));
-        Self { input, inner }
-    }
-}
-
-impl<F: BigPrimeField> Circuit<F> for StateTransitionCircuit<F> {
-    type Config = BaseConfig<F>;
-    type FloorPlanner = SimpleFloorPlanner;
-    type Params = BaseCircuitParams;
-
-    fn params(&self) -> Self::Params {
-        self.inner.params()
-    }
-
-    fn without_witnesses(&self) -> Self {
-        unimplemented!()
-    }
-
-    fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
-        BaseCircuitBuilder::configure_with_params(meta, params)
-    }
-
-    fn configure(_: &mut ConstraintSystem<F>) -> Self::Config {
-        unreachable!()
-    }
-
-    fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
-        self.inner.synthesize(config, layouter)
-    }
-}
-
-impl<F: BigPrimeField> CircuitExt<F> for StateTransitionCircuit<F> {
-    fn num_instance() -> Vec<usize> {
-        vec![70]
-    }
-
-    fn instances(&self) -> Vec<Vec<F>> {
-        vec![
-            self.inner.assigned_instances[0]
-                .iter()
-                .map(|instance| *instance.value())
-                .collect()
-        ]
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use halo2_base::{
-        gates::circuit::BaseCircuitParams,
-        halo2_proofs::{ dev::MockProver, halo2curves::bn256::Fr },
-        utils::testing::base_test,
-        AssignedValue,
-    };
-    use voter::CircuitExt;
-
-    use crate::utils::generate_wrapper_circuit_input;
-
-    use super::{ state_transition_circuit, StateTransitionCircuit };
-
-    #[test]
-    fn test_state_transition_circuit() {
-        let (_, multiple_input) = generate_wrapper_circuit_input(4);
-
-        let config = BaseCircuitParams {
-            k: 15,
-            num_advice_per_phase: vec![3],
-            num_lookup_advice_per_phase: vec![1, 0, 0],
-            num_fixed: 1,
-            lookup_bits: Some(14),
-            num_instance_columns: 1,
-        };
-
-        for (round, input) in multiple_input.iter().enumerate() {
-            println!("------round[{}]--------", round);
-
-            let circuit = StateTransitionCircuit::new(config.clone(), input.clone());
-            let prover = MockProver::run(15, &circuit, circuit.instances()).unwrap();
-            prover.verify().unwrap();
-        }
-
-        base_test()
-            .k(19)
-            .lookup_bits(18)
-            .expect_satisfied(true)
-            .run(|ctx, range| {
-                let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
-                state_transition_circuit(ctx, range, multiple_input[0].clone(), &mut public_inputs)
-            });
-    }
 }

--- a/aggregator/src/state_transition.rs
+++ b/aggregator/src/state_transition.rs
@@ -71,6 +71,9 @@ impl<F: BigPrimeField> IndexedMerkleTreeInput<F> {
     pub fn get_old_root(&self) -> F {
         self.old_root
     }
+    pub fn get_new_root(&self) -> F {
+        self.new_root
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/aggregator/src/utils.rs
+++ b/aggregator/src/utils.rs
@@ -3,7 +3,8 @@ use halo2_base::halo2_proofs::halo2curves::bn256::Fr;
 use halo2_base::halo2_proofs::halo2curves::group::Curve;
 use halo2_base::halo2_proofs::halo2curves::secp256k1::{Fq, Secp256k1, Secp256k1Affine};
 use halo2_base::halo2_proofs::halo2curves::secq256k1::Fp;
-use halo2_base::utils::{fe_to_biguint, ScalarField};
+use halo2_base::utils::{fe_to_biguint, BigPrimeField, ScalarField};
+use halo2_base::{AssignedValue, Context};
 use halo2_ecc::*;
 use num_bigint::{BigUint, RandBigInt};
 use paillier_chip::paillier::{paillier_add_native, paillier_enc_native};
@@ -492,4 +493,15 @@ pub fn generate_random_state_transition_circuit_inputs() -> StateTransitionInput
     };
 
     input
+}
+
+pub fn assign_big_uint<F: BigPrimeField>(
+    ctx: &mut Context<F>,
+    value: &BigUint,
+) -> Vec<AssignedValue<F>> {
+    let limbs = value.to_u64_digits();
+    limbs
+        .into_iter()
+        .map(|limb| ctx.load_witness(F::from(limb)))
+        .collect()
 }

--- a/voter/src/lib.rs
+++ b/voter/src/lib.rs
@@ -247,9 +247,11 @@ pub fn voter_circuit<F: BigPrimeField>(
     // ctx.constrain_equal(&vote_sum_assigned, &one);
 
     //PK_ENC_n
+    println!("pk_enc n : {:?}", pk_enc.n.limbs().to_vec());
     public_inputs.extend(pk_enc.n.limbs().to_vec());
 
     //PK_ENC_g
+    println!("pk_enc n : {:?}", pk_enc.n.limbs().to_vec());
     public_inputs.extend(pk_enc.g.limbs().to_vec());
 
     // 2. Verify correct vote encryption


### PR DESCRIPTION
### Changes

- optimized state_transition_circuit
- updated benches circuit according new witness values

| Bench Name     | Benchmark Time | Max Memory Usage |
|------------------|----------------|------------------|
| wrapper_circuit    |    121.36 sec   |     17.13 GB|
| state_transition    | 583.79  ms      | 0.33 GB      |
| voter_benches    | 301.04 ms      | 0.26 GB          |
| voter_test    | 301.27 ms      | 0.26 GB          |

entire memory usage was calculated by the crate [memory-stats](https://crates.io/crates/memory-stats)
<!---
![image](https://github.com/user-attachments/assets/cec09eb8-1035-4de2-aa80-447be0af4b03)
-->

![image](https://github.com/user-attachments/assets/8e84663c-c60c-488c-b482-509d7332d8e3)

