### PR TITLE
chore(test): remove commented base_test

### DIFF
--- a/voter_tests/src/lib.rs
+++ b/voter_tests/src/lib.rs
@@ -238,17 +238,5 @@ mod test {
         let circuit = VoterCircuit::new(config, input.clone());
         let prover = MockProver::run(15, &circuit, circuit.instances()).unwrap();
         prover.verify().unwrap();
-
-        // base_test()
-        //     .k(15)
-        //     .lookup_bits(14)
-        //     .expect_satisfied(true)
-        //     .run_builder(|pool, range| {
-        //         let ctx = pool.main();
-
-        //         let mut public_inputs = Vec::<AssignedValue<Fr>>::new();
-
-        //         voter_circuit(ctx, &range, input, &mut public_inputs);
-        //     })
     }
 }


### PR DESCRIPTION
Removed commented-out base_test code from lib.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unused test configuration code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->